### PR TITLE
Adds documentation for sphinx

### DIFF
--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -484,6 +484,8 @@ influence the build process. The build process consists of the following parts:
   * ``hpx``: The core |hpx| library (always enabled).
   * ``hpx_init``: The |hpx| initialization library that applications need to
     link against to define the |hpx| entry points (disabled for static builds).
+  * ``hpx_wrap``: The |hpx| static library used to determine the runtime
+    behavior of |hpx| code and respective entry points for ``hpx_main.h``
   * ``iostreams_component``: The component used for (distributed) IO (always
     enabled).
   * ``component_storage_component``: The component needed for migration to
@@ -1269,3 +1271,25 @@ How to install |hpx| on Fedora distributions
 .. include:: ../../generated/cmake_toolchains.rst
 
 .. include:: ../../generated/cmake_variables.rst
+
+.. _arch_installation
+
+How to install |hpx| on Arch distributions
+------------------------------------------
+
+* Install all packages for minimal installation:
+
+  .. code-block:: bash
+
+     sudo pacman -S gcc clang cmake boost hwloc gperftools
+
+* For building the docs you will need to further install the following:
+
+  .. code-block:: bash
+
+     sudo pacman -S doxygen python-pip
+  
+     pip install --user sphinx sphinx_rtd_theme breathe
+
+The rest of the installation steps are same as provided with fedora
+or Unix variants.

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -1268,10 +1268,6 @@ How to install |hpx| on Fedora distributions
      sudo echo /opt/hpx/lib > /etc/ld.so.conf.d/hpx.conf
      sudo ldconfig
 
-.. include:: ../../generated/cmake_toolchains.rst
-
-.. include:: ../../generated/cmake_variables.rst
-
 .. _arch_installation
 
 How to install |hpx| on Arch distributions
@@ -1283,7 +1279,7 @@ How to install |hpx| on Arch distributions
 
      sudo pacman -S gcc clang cmake boost hwloc gperftools
 
-* For building the docs you will need to further install the following:
+* For building the documentation you will need to further install the following:
 
   .. code-block:: bash
 
@@ -1291,5 +1287,9 @@ How to install |hpx| on Arch distributions
   
      pip install --user sphinx sphinx_rtd_theme breathe
 
-The rest of the installation steps are same as provided with fedora
+The rest of the installation steps are same as provided with Fedora
 or Unix variants.
+
+.. include:: ../../generated/cmake_toolchains.rst
+
+.. include:: ../../generated/cmake_variables.rst

--- a/docs/sphinx/manual/creating_hpx_projects.rst
+++ b/docs/sphinx/manual/creating_hpx_projects.rst
@@ -12,6 +12,144 @@
 Creating |hpx| projects
 =======================
 
+.. _makefile:
+
+Using HPX with Makefile
+=======================
+
+A basic project building with |hpx| is through creating makefiles. The process
+of creating one can get complex depending upon the use of cmake parameter
+``HPX_WITH_HPX_MAIN`` (which defaults to ON).
+
+How to build |hpx| applications with makefile
+---------------------------------------------
+
+If |hpx| is installed correctly, you should be able to build and run a simple
+hello world program. It prints ``Hello World!`` on the :term:`locality` you
+run it on.
+
+.. literalinclude:: ../../examples/quickstart/simplest_hello_world_1.cpp
+   :language: c++
+
+Copy the content of this program into a file called hello_world.cpp.
+
+Now in the directory where you put hello_world.cpp, create a Makefile.
+Add the following code:
+
+.. code-block:: makefile
+   
+   CXX=(CXX)  # Add your favourite compiler here or let makefile choose default.
+
+   CXXFLAGS=-O3 -std=c++17
+
+   BOOST_ROOT=/path/to/boost
+   HWLOC_ROOT=/path/to/hwloc
+   TCMALLOC_ROOT=/path/to/tcmalloc
+   HPX_ROOT=/path/to/hpx
+
+   INCLUDE_DIRECTIVES=$(HPX_ROOT)/include $(BOOST_ROOT)/include $(HWLOC_ROOT)/include
+
+   LIBRARY_DIRECTIVES=-L$(HPX_ROOT)/lib $(HPX_ROOT)/lib/libhpx_init.a $(HPX_ROOT)/lib/libhpx.so $(BOOST_ROOT)/lib/libboost_atomic-mt.so $(BOOST_ROOT)/lib/libboost_filesystem-mt.so $(BOOST_ROOT)/lib/libboost_program_options-mt.so $(BOOST_ROOT)/lib/libboost_regex-mt.so $(BOOST_ROOT)/lib/libboost_system-mt.so -lpthread $(TCMALLOC_ROOT)/libtcmalloc_minimal.so $(HWLOC_ROOT)/libhwloc.so -ldl -lrt
+
+   LINK_FLAGS=$(HPX_ROOT)/lib/libhpx_wrap.a -Wl,-wrap=main  # should be left empty for HPX_WITH_HPX_MAIN=OFF
+
+   hello_world: hello_world.o
+      $(CXX) $(CXXFLAGS) -o hello_world hello_world.o $(LIBRARY_DIRECTIVES) $(LINK_FLAGS)
+
+   hello_world.o:
+      $(CXX) $(CXXFLAGS) -c -o hello_world.o hello_world.cpp $(INCLUDE_DIRECTIVES)
+
+.. important::
+   
+   ``LINK_FLAGS`` should be left empty if HPX_WITH_HPX_MAIN is set to OFF.
+   Boost in the above example is build with ``--layout=tagged``. Actual boost
+   flags may vary on your build of your boost.
+
+To build the program, type:
+
+.. code-block:: bash
+
+   make
+
+A successfull build should result in hello_world binary. To test, type:
+
+.. code-block:: bash
+
+   ./hello_world
+
+How to build |hpx| components with makefile
+-------------------------------------------
+
+Let's try a more complex example involving an |hpx| component. An |hpx|
+component is a class which exposes |hpx| actions. |hpx| components are compiled
+into dynamically loaded modules called component libraries. Here's the source
+code:
+
+**hello_world_component.cpp**
+
+.. literalinclude:: ../../examples/hello_world_component/hello_world_component.cpp
+   :language: c++
+   :lines: 7-29
+
+**hello_world_component.hpp**
+
+.. literalinclude:: ../../examples/hello_world_component/hello_world_component.hpp
+   :language: c++
+   :lines: 7-54
+
+**hello_world_client.cpp**
+
+.. literalinclude:: ../../examples/hello_world_component/hello_world_client.cpp
+   :language: c++
+
+Now in the directory, create a Makefile. Add the following code:
+
+.. code-block:: makefile
+   
+   CXX=(CXX)  # Add your favourite compiler here or let makefile choose default.
+
+   CXXFLAGS=-O3 -std=c++17
+
+   BOOST_ROOT=/path/to/boost
+   HWLOC_ROOT=/path/to/hwloc
+   TCMALLOC_ROOT=/path/to/tcmalloc
+   HPX_ROOT=/path/to/hpx
+
+   INCLUDE_DIRECTIVES=$(HPX_ROOT)/include $(BOOST_ROOT)/include $(HWLOC_ROOT)/include
+
+   LIBRARY_DIRECTIVES=-L$(HPX_ROOT)/lib $(HPX_ROOT)/lib/libhpx_init.a $(HPX_ROOT)/lib/libhpx.so $(BOOST_ROOT)/lib/libboost_atomic-mt.so $(BOOST_ROOT)/lib/libboost_filesystem-mt.so $(BOOST_ROOT)/lib/libboost_program_options-mt.so $(BOOST_ROOT)/lib/libboost_regex-mt.so $(BOOST_ROOT)/lib/libboost_system-mt.so -lpthread $(TCMALLOC_ROOT)/libtcmalloc_minimal.so $(HWLOC_ROOT)/libhwloc.so -ldl -lrt
+
+   LINK_FLAGS=$(HPX_ROOT)/lib/libhpx_wrap.a -Wl,-wrap=main  # should be left empty for HPX_WITH_HPX_MAIN=OFF
+
+   hello_world_client: libhpx_hello_world hello_world_client.o
+     $(CXX) $(CXXFLAGS) -o hello_world_client $(LIBRARY_DIRECTIVES) libhpx_hello_world $(LINK_FLAGS)
+
+   hello_world_client.o: hello_world_client.cpp
+     $(CXX) $(CXXFLAGS) -o hello_world_client.o hello_world_client.cpp $(INCLUDE_DIRECTIVES)
+
+   libhpx_hello_world: hello_world_component.o
+     $(CXX) $(CXXFLAGS) -o libhpx_hello_world hello_world_component.o $(LIBRARY_DIRECTIVES)
+
+   hello_world_component.o: hello_world_component.cpp
+     $(CXX) $(CXXFLAGS) -c -o hello_world_component.o hello_world_component.cpp $(INCLUDE_DIRECTIVES)
+
+To build the program, type:
+
+.. code-block:: bash
+
+   make
+
+A successfull build should result in hello_world binary. To test, type:
+
+.. code-block:: bash
+
+   ./hello_world
+
+.. note::
+   
+   Using pkg-config or CMakeLists.txt for building |hpx| applications and
+   components is a better alternative than using Makefile.
+
 .. _pkgconfig:
 
 Using HPX with pkg-config

--- a/docs/sphinx/manual/creating_hpx_projects.rst
+++ b/docs/sphinx/manual/creating_hpx_projects.rst
@@ -12,144 +12,6 @@
 Creating |hpx| projects
 =======================
 
-.. _makefile:
-
-Using HPX with Makefile
-=======================
-
-A basic project building with |hpx| is through creating makefiles. The process
-of creating one can get complex depending upon the use of cmake parameter
-``HPX_WITH_HPX_MAIN`` (which defaults to ON).
-
-How to build |hpx| applications with makefile
----------------------------------------------
-
-If |hpx| is installed correctly, you should be able to build and run a simple
-hello world program. It prints ``Hello World!`` on the :term:`locality` you
-run it on.
-
-.. literalinclude:: ../../examples/quickstart/simplest_hello_world_1.cpp
-   :language: c++
-
-Copy the content of this program into a file called hello_world.cpp.
-
-Now in the directory where you put hello_world.cpp, create a Makefile.
-Add the following code:
-
-.. code-block:: makefile
-   
-   CXX=(CXX)  # Add your favourite compiler here or let makefile choose default.
-
-   CXXFLAGS=-O3 -std=c++17
-
-   BOOST_ROOT=/path/to/boost
-   HWLOC_ROOT=/path/to/hwloc
-   TCMALLOC_ROOT=/path/to/tcmalloc
-   HPX_ROOT=/path/to/hpx
-
-   INCLUDE_DIRECTIVES=$(HPX_ROOT)/include $(BOOST_ROOT)/include $(HWLOC_ROOT)/include
-
-   LIBRARY_DIRECTIVES=-L$(HPX_ROOT)/lib $(HPX_ROOT)/lib/libhpx_init.a $(HPX_ROOT)/lib/libhpx.so $(BOOST_ROOT)/lib/libboost_atomic-mt.so $(BOOST_ROOT)/lib/libboost_filesystem-mt.so $(BOOST_ROOT)/lib/libboost_program_options-mt.so $(BOOST_ROOT)/lib/libboost_regex-mt.so $(BOOST_ROOT)/lib/libboost_system-mt.so -lpthread $(TCMALLOC_ROOT)/libtcmalloc_minimal.so $(HWLOC_ROOT)/libhwloc.so -ldl -lrt
-
-   LINK_FLAGS=$(HPX_ROOT)/lib/libhpx_wrap.a -Wl,-wrap=main  # should be left empty for HPX_WITH_HPX_MAIN=OFF
-
-   hello_world: hello_world.o
-      $(CXX) $(CXXFLAGS) -o hello_world hello_world.o $(LIBRARY_DIRECTIVES) $(LINK_FLAGS)
-
-   hello_world.o:
-      $(CXX) $(CXXFLAGS) -c -o hello_world.o hello_world.cpp $(INCLUDE_DIRECTIVES)
-
-.. important::
-   
-   ``LINK_FLAGS`` should be left empty if HPX_WITH_HPX_MAIN is set to OFF.
-   Boost in the above example is build with ``--layout=tagged``. Actual boost
-   flags may vary on your build of your boost.
-
-To build the program, type:
-
-.. code-block:: bash
-
-   make
-
-A successfull build should result in hello_world binary. To test, type:
-
-.. code-block:: bash
-
-   ./hello_world
-
-How to build |hpx| components with makefile
--------------------------------------------
-
-Let's try a more complex example involving an |hpx| component. An |hpx|
-component is a class which exposes |hpx| actions. |hpx| components are compiled
-into dynamically loaded modules called component libraries. Here's the source
-code:
-
-**hello_world_component.cpp**
-
-.. literalinclude:: ../../examples/hello_world_component/hello_world_component.cpp
-   :language: c++
-   :lines: 7-29
-
-**hello_world_component.hpp**
-
-.. literalinclude:: ../../examples/hello_world_component/hello_world_component.hpp
-   :language: c++
-   :lines: 7-54
-
-**hello_world_client.cpp**
-
-.. literalinclude:: ../../examples/hello_world_component/hello_world_client.cpp
-   :language: c++
-
-Now in the directory, create a Makefile. Add the following code:
-
-.. code-block:: makefile
-   
-   CXX=(CXX)  # Add your favourite compiler here or let makefile choose default.
-
-   CXXFLAGS=-O3 -std=c++17
-
-   BOOST_ROOT=/path/to/boost
-   HWLOC_ROOT=/path/to/hwloc
-   TCMALLOC_ROOT=/path/to/tcmalloc
-   HPX_ROOT=/path/to/hpx
-
-   INCLUDE_DIRECTIVES=$(HPX_ROOT)/include $(BOOST_ROOT)/include $(HWLOC_ROOT)/include
-
-   LIBRARY_DIRECTIVES=-L$(HPX_ROOT)/lib $(HPX_ROOT)/lib/libhpx_init.a $(HPX_ROOT)/lib/libhpx.so $(BOOST_ROOT)/lib/libboost_atomic-mt.so $(BOOST_ROOT)/lib/libboost_filesystem-mt.so $(BOOST_ROOT)/lib/libboost_program_options-mt.so $(BOOST_ROOT)/lib/libboost_regex-mt.so $(BOOST_ROOT)/lib/libboost_system-mt.so -lpthread $(TCMALLOC_ROOT)/libtcmalloc_minimal.so $(HWLOC_ROOT)/libhwloc.so -ldl -lrt
-
-   LINK_FLAGS=$(HPX_ROOT)/lib/libhpx_wrap.a -Wl,-wrap=main  # should be left empty for HPX_WITH_HPX_MAIN=OFF
-
-   hello_world_client: libhpx_hello_world hello_world_client.o
-     $(CXX) $(CXXFLAGS) -o hello_world_client $(LIBRARY_DIRECTIVES) libhpx_hello_world $(LINK_FLAGS)
-
-   hello_world_client.o: hello_world_client.cpp
-     $(CXX) $(CXXFLAGS) -o hello_world_client.o hello_world_client.cpp $(INCLUDE_DIRECTIVES)
-
-   libhpx_hello_world: hello_world_component.o
-     $(CXX) $(CXXFLAGS) -o libhpx_hello_world hello_world_component.o $(LIBRARY_DIRECTIVES)
-
-   hello_world_component.o: hello_world_component.cpp
-     $(CXX) $(CXXFLAGS) -c -o hello_world_component.o hello_world_component.cpp $(INCLUDE_DIRECTIVES)
-
-To build the program, type:
-
-.. code-block:: bash
-
-   make
-
-A successfull build should result in hello_world binary. To test, type:
-
-.. code-block:: bash
-
-   ./hello_world
-
-.. note::
-   
-   Using pkg-config or CMakeLists.txt for building |hpx| applications and
-   components is a better alternative than using Makefile.
-
 .. _pkgconfig:
 
 Using HPX with pkg-config
@@ -481,3 +343,145 @@ to the section on :ref:`comps`.
    your project after all libraries you want to link against have been added.
    Please also consult the CMake documentation `here
    <https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling>`_.
+
+.. _makefile:
+
+Using HPX with Makefile
+=======================
+
+A basic project building with |hpx| is through creating makefiles. The process
+of creating one can get complex depending upon the use of cmake parameter
+``HPX_WITH_HPX_MAIN`` (which defaults to ON).
+
+How to build |hpx| applications with makefile
+---------------------------------------------
+
+If |hpx| is installed correctly, you should be able to build and run a simple
+hello world program. It prints ``Hello World!`` on the :term:`locality` you
+run it on.
+
+.. literalinclude:: ../../examples/quickstart/simplest_hello_world_1.cpp
+   :language: c++
+
+Copy the content of this program into a file called hello_world.cpp.
+
+Now in the directory where you put hello_world.cpp, create a Makefile.
+Add the following code:
+
+.. code-block:: makefile
+   
+   CXX=(CXX)  # Add your favourite compiler here or let makefile choose default.
+
+   CXXFLAGS=-O3 -std=c++17
+
+   BOOST_ROOT=/path/to/boost
+   HWLOC_ROOT=/path/to/hwloc
+   TCMALLOC_ROOT=/path/to/tcmalloc
+   HPX_ROOT=/path/to/hpx
+
+   INCLUDE_DIRECTIVES=$(HPX_ROOT)/include $(BOOST_ROOT)/include $(HWLOC_ROOT)/include
+
+   LIBRARY_DIRECTIVES=-L$(HPX_ROOT)/lib $(HPX_ROOT)/lib/libhpx_init.a $(HPX_ROOT)/lib/libhpx.so $(BOOST_ROOT)/lib/libboost_atomic-mt.so $(BOOST_ROOT)/lib/libboost_filesystem-mt.so $(BOOST_ROOT)/lib/libboost_program_options-mt.so $(BOOST_ROOT)/lib/libboost_regex-mt.so $(BOOST_ROOT)/lib/libboost_system-mt.so -lpthread $(TCMALLOC_ROOT)/libtcmalloc_minimal.so $(HWLOC_ROOT)/libhwloc.so -ldl -lrt
+
+   LINK_FLAGS=$(HPX_ROOT)/lib/libhpx_wrap.a -Wl,-wrap=main  # should be left empty for HPX_WITH_HPX_MAIN=OFF
+
+   hello_world: hello_world.o
+      $(CXX) $(CXXFLAGS) -o hello_world hello_world.o $(LIBRARY_DIRECTIVES) $(LINK_FLAGS)
+
+   hello_world.o:
+      $(CXX) $(CXXFLAGS) -c -o hello_world.o hello_world.cpp $(INCLUDE_DIRECTIVES)
+
+.. important::
+   
+   ``LINK_FLAGS`` should be left empty if HPX_WITH_HPX_MAIN is set to OFF.
+   Boost in the above example is build with ``--layout=tagged``. Actual boost
+   flags may vary on your build of boost.
+
+To build the program, type:
+
+.. code-block:: bash
+
+   make
+
+A successfull build should result in hello_world binary. To test, type:
+
+.. code-block:: bash
+
+   ./hello_world
+
+How to build |hpx| components with makefile
+-------------------------------------------
+
+Let's try a more complex example involving an |hpx| component. An |hpx|
+component is a class which exposes |hpx| actions. |hpx| components are compiled
+into dynamically loaded modules called component libraries. Here's the source
+code:
+
+**hello_world_component.cpp**
+
+.. literalinclude:: ../../examples/hello_world_component/hello_world_component.cpp
+   :language: c++
+   :lines: 7-29
+
+**hello_world_component.hpp**
+
+.. literalinclude:: ../../examples/hello_world_component/hello_world_component.hpp
+   :language: c++
+   :lines: 7-54
+
+**hello_world_client.cpp**
+
+.. literalinclude:: ../../examples/hello_world_component/hello_world_client.cpp
+   :language: c++
+
+Now in the directory, create a Makefile. Add the following code:
+
+.. code-block:: makefile
+   
+   CXX=(CXX)  # Add your favourite compiler here or let makefile choose default.
+
+   CXXFLAGS=-O3 -std=c++17
+
+   BOOST_ROOT=/path/to/boost
+   HWLOC_ROOT=/path/to/hwloc
+   TCMALLOC_ROOT=/path/to/tcmalloc
+   HPX_ROOT=/path/to/hpx
+
+   INCLUDE_DIRECTIVES=$(HPX_ROOT)/include $(BOOST_ROOT)/include $(HWLOC_ROOT)/include
+
+   LIBRARY_DIRECTIVES=-L$(HPX_ROOT)/lib $(HPX_ROOT)/lib/libhpx_init.a $(HPX_ROOT)/lib/libhpx.so $(BOOST_ROOT)/lib/libboost_atomic-mt.so $(BOOST_ROOT)/lib/libboost_filesystem-mt.so $(BOOST_ROOT)/lib/libboost_program_options-mt.so $(BOOST_ROOT)/lib/libboost_regex-mt.so $(BOOST_ROOT)/lib/libboost_system-mt.so -lpthread $(TCMALLOC_ROOT)/libtcmalloc_minimal.so $(HWLOC_ROOT)/libhwloc.so -ldl -lrt
+
+   LINK_FLAGS=$(HPX_ROOT)/lib/libhpx_wrap.a -Wl,-wrap=main  # should be left empty for HPX_WITH_HPX_MAIN=OFF
+
+   hello_world_client: libhpx_hello_world hello_world_client.o
+     $(CXX) $(CXXFLAGS) -o hello_world_client $(LIBRARY_DIRECTIVES) libhpx_hello_world $(LINK_FLAGS)
+
+   hello_world_client.o: hello_world_client.cpp
+     $(CXX) $(CXXFLAGS) -o hello_world_client.o hello_world_client.cpp $(INCLUDE_DIRECTIVES)
+
+   libhpx_hello_world: hello_world_component.o
+     $(CXX) $(CXXFLAGS) -o libhpx_hello_world hello_world_component.o $(LIBRARY_DIRECTIVES)
+
+   hello_world_component.o: hello_world_component.cpp
+     $(CXX) $(CXXFLAGS) -c -o hello_world_component.o hello_world_component.cpp $(INCLUDE_DIRECTIVES)
+
+To build the program, type:
+
+.. code-block:: bash
+
+   make
+
+A successfull build should result in hello_world binary. To test, type:
+
+.. code-block:: bash
+
+   ./hello_world
+
+.. note::
+   
+   Due to high variations in CMake flags and library dependencies, it is
+   recommended to build |hpx| applications and components with pkg-config
+   or CMakeLists.txt. Writing Makefile may result in broken builds if
+   due care is not taken.
+   pkg-config files and CMake systems are configured with CMake build of
+   |hpx|. Hence, they are stable and provides with better support overall.


### PR DESCRIPTION
This PR adds the following to documentation:

- [x] Makefile documentation for building `HPX` application and components
- [x] Installation scripts and commands to make it easier for the user to install `HPX` (The current version is already well written, I will add a bit more to make it even clearer)

I would discourage the use of `makefile` for building `HPX` applications since pkg-config and cmake system templates generate appropriate flags.

### Edit

I found the current documentation nicely written. There's a separate fedora section that makes it easier to install `hpx` on fedora. I've added `arch` to the list so as to provide installation guide for most Linux distros